### PR TITLE
'fix ranges'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(exclusive_range_pattern)]
 #[macro_use]
 extern crate diesel;
 extern crate bigdecimal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,6 @@ extern crate log;
 extern crate oci_sys;
 pub mod oracle;
 
-extern crate num;
-#[macro_use]
-extern crate num_derive;
-
 #[cfg(test)]
 mod test;
 

--- a/src/oracle/connection/stmt.rs
+++ b/src/oracle/connection/stmt.rs
@@ -298,9 +298,9 @@ impl Statement {
                     )?;
                     if scale == 0 {
                         tpe_size = match precision {
-                            1..5 => 2,   // number(5) -> smallint
-                            6..10 => 4,  // number(10) -> int
-                            11..19 => 8, // number(19) -> bigint
+                            1..=5 => 2,   // number(5) -> smallint
+                            6..=10 => 4,  // number(10) -> int
+                            11..=19 => 8, // number(19) -> bigint
                             _ => 21,     // number(38) -> consume_all // TODO: use numeric(diesel)
                         };
                         tpe = ffi::SQLT_INT;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,5 +1,8 @@
 extern crate chrono;
 extern crate dotenv;
+extern crate num;
+#[macro_use]
+extern crate num_derive;
 use self::chrono::NaiveDateTime;
 use self::dotenv::dotenv;
 use super::oracle::connection::OciConnection;


### PR DESCRIPTION
Inclusive ranges (`..=`) are stable since 1.26.