### PR TITLE
using OCI builtin function to determine statement types

### DIFF
--- a/src/oracle/connection/cursor.rs
+++ b/src/oracle/connection/cursor.rs
@@ -98,10 +98,8 @@ where
                     return None;
                 }
             }
-        } else {
-            if self.current_row > 0 {
-                return None;
-            }
+        } else if self.current_row > 0 {
+            return None;
         }
 
         self.current_row += 1;

--- a/src/oracle/connection/mod.rs
+++ b/src/oracle/connection/mod.rs
@@ -149,8 +149,7 @@ impl Connection for OciConnection {
         let mut stmt = self.prepare_query(&source)?;
         let mut metadata = Vec::new();
         stmt.get_metadata(&mut metadata)?;
-        let mut cursor: NamedCursor =
-            NamedCursor::from(stmt.run_with_named_cursor(self.auto_commit(), metadata)?);
+        let mut cursor: NamedCursor = stmt.run_with_named_cursor(self.auto_commit(), metadata)?;
         cursor.collect()
     }
 }

--- a/src/oracle/connection/row.rs
+++ b/src/oracle/connection/row.rs
@@ -65,7 +65,7 @@ impl<'a> NamedRow<Oracle> for NamedOciRow<'a> {
         self.lut.get(column_name).map(|ci| *ci as usize)
     }
     fn get_raw_value(&self, index: usize) -> Option<&OracleValue> {
-        let ret = if index < self.buf.len() {
+        if index < self.buf.len() {
             if self.is_null[index] {
                 None
             } else {
@@ -73,7 +73,6 @@ impl<'a> NamedRow<Oracle> for NamedOciRow<'a> {
             }
         } else {
             None
-        };
-        ret
+        }
     }
 }

--- a/src/oracle/connection/stmt.rs
+++ b/src/oracle/connection/stmt.rs
@@ -692,7 +692,7 @@ impl Statement {
             }
 
             metadata.push(OciDataType::from_sqlt(tpe, tpe_size));
-            cnt = cnt + 1;
+            cnt += 1;
             param = self.get_column_param(cnt);
         }
         Ok(())

--- a/src/oracle/types/chrono_date_time.rs
+++ b/src/oracle/types/chrono_date_time.rs
@@ -56,17 +56,15 @@ impl ToSql<Timestamp, Oracle> for NaiveDateTime {
         if year > 0 {
             let c: u8 = (year / 100 + 100) as u8;
             let y: u8 = (year % 100 + 100) as u8;
-            try!(
-                out.write(&[c, y])
-                    .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-            );
+            try!(out
+                .write(&[c, y])
+                .map_err(|e| Box::new(e) as Box<Error + Send + Sync>));
         } else {
             let c: u8 = (year / 100) as u8;
             let y: u8 = (year % 100) as u8;
-            try!(
-                out.write(&[c, y])
-                    .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-            );
+            try!(out
+                .write(&[c, y])
+                .map_err(|e| Box::new(e) as Box<Error + Send + Sync>));
         }
         let mo = self.month() as u8;
         let d = self.day() as u8;
@@ -108,17 +106,15 @@ impl ToSql<Date, Oracle> for NaiveDate {
         if year > 0 {
             let c: u8 = (year / 100 + 100) as u8;
             let y: u8 = (year % 100 + 100) as u8;
-            try!(
-                out.write(&[c, y])
-                    .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-            );
+            try!(out
+                .write(&[c, y])
+                .map_err(|e| Box::new(e) as Box<Error + Send + Sync>));
         } else {
             let c: u8 = (year / 100) as u8;
             let y: u8 = (year % 100) as u8;
-            try!(
-                out.write(&[c, y])
-                    .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-            );
+            try!(out
+                .write(&[c, y])
+                .map_err(|e| Box::new(e) as Box<Error + Send + Sync>));
         }
         let mo = self.month() as u8;
         let d = self.day() as u8;

--- a/src/oracle/types/mod.rs
+++ b/src/oracle/types/mod.rs
@@ -6,7 +6,6 @@ use diesel::deserialize::FromSql;
 use diesel::serialize::{IsNull, Output, ToSql};
 use diesel::sql_types::*;
 use oci_sys as ffi;
-use std::collections::btree_map::Entry::Occupied;
 use std::error::Error;
 use std::io::Write;
 


### PR DESCRIPTION
with this we can safely determine if we have a select statement or a returning clause attached. this requires no round trip. it also fixes the detection if we have a DDL statement and thus need to run/execute the statement twice.

another one: this allows `WITH` clauses

fixes: #8
fixes: #7