### PR TITLE
Provide a custom implementation of

### DIFF
--- a/src/oracle/connection/transaction.rs
+++ b/src/oracle/connection/transaction.rs
@@ -132,4 +132,17 @@ impl TransactionManager<OciConnection> for OCITransactionManager {
     ) -> &mut diesel::connection::TransactionManagerStatus {
         &mut conn.transaction_manager.status
     }
+
+    fn is_broken_transaction_manager(conn: &mut OciConnection) -> bool {
+        let transaction_depth = Self::get_transaction_depth(conn);
+
+        match transaction_depth {
+            Err(_) => true,
+            Ok(None) => false,
+            Ok(Some(v)) if conn.transaction_manager.is_test_transaction && u32::from(v) == 1 => {
+                false
+            }
+            Ok(Some(_)) => true,
+        }
+    }
 }


### PR DESCRIPTION
`TransactionManager::is_broken_transaction_manager`

This fixes considering connections with `begin_test_transaction` as broken, as we are currently not able to set the right flag in the diesel internal implementation. I plan to address that on the diesel side as well, but that's an easier fix here.