### PR TITLE
Fix type mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-
 jobs:
   rustfmt:
     runs-on: ubuntu-latest
@@ -39,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         rust_toolchain: ["stable", "beta", "nightly"]
 
     runs-on: ${{ matrix.os }}
@@ -60,6 +59,11 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y libaio1
 
       - name: Install the latest Oracle instant client
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Daniel Buse <daniel.buse@giga-infosystems.com>",
 ]
 name = "diesel-oci"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT OR Apache-2.0"
 description = "A oci database adapter for diesel"
 readme = "README.md"
@@ -43,7 +43,7 @@ version = "0.2.1"
 log = "0.4"
 dotenvy = "0.15"
 num = { version = "0.4", default-features = false }
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 
 [features]

--- a/src/oracle/connection/row.rs
+++ b/src/oracle/connection/row.rs
@@ -55,7 +55,8 @@ impl RowSealed for OciRow {}
 
 impl<'a> Row<'a, Oracle> for OciRow {
     type InnerPartialRow = Self;
-    type Field<'f> = OciField<'f>
+    type Field<'f>
+        = OciField<'f>
     where
         'a: 'f,
         Self: 'f;


### PR DESCRIPTION
This commit makes mapping oracle NUMBER types to diesel integer types more robust and adds a test to verify that the behaviour is as expected. It also prepares a new patch release.